### PR TITLE
Removed redundant associated type

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,9 @@ jobs:
     steps:
       - name: Checkout Git
         uses: actions/checkout@v2
-
+        with:
+          fetch-depth: 0
+          
       - name: ruby versions
         run: |
           ruby --version

--- a/Sources/QAMenuUtils/Public/Logger/Logger.swift
+++ b/Sources/QAMenuUtils/Public/Logger/Logger.swift
@@ -32,15 +32,11 @@ public struct Logger {
 
     // MARK: - Properties (Public)
 
-    public enum Level: Int, Comparable {
-        case verbose = 0
+    public enum Level: Comparable {
+        case verbose
         case warning
         case error
         case none
-
-        public static func < (lhs: Level, rhs: Level) -> Bool {
-            return lhs.rawValue < rhs.rawValue
-        }
     }
 
     public static var logLevel: Level = .error


### PR DESCRIPTION
Removed redundant associated type. The changes were presented in Swift 5.3