### PR TITLE
Prevent Danger from failing if running in PRs from forks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout Git
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: ruby versions
         run: |


### PR DESCRIPTION
This fix proved to prevent Danger from failing in #4 and is based on the Danger issue https://github.com/danger/danger/issues/1103. 

The following warning in the log looks suspicious, the issues should therefore be revisited in future:

```
Danger does not have write access to the PR to set a PR status
``` 