### PR TITLE
Persist trigger and dismiss behavior configuration in user defaults

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -20,7 +20,6 @@ opt_in_rules:
   - file_name_no_space
   - file_types_order
   - force_unwrapping
-  - let_var_whitespace
   - lower_acl_than_parent
   - modifier_order
   - multiline_arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@
 #### Breaking Changes
 
 * [QAMenu] Renamed parameter `isSearchable` to `isPaneSearchable` in `Item.asChildPaneItem()` (MR #6)
+* [QAMenu] Removed parameter `trigger` from `QAMenu()` in favor of `QAMenu.setTrigger()` (MR #7)
+* [QAMenu] Renamed `QAMenuDismissBehavior` to `QAMenu.DismissBehavior()` (MR #7)
 
 #### Enhancements
 
 * [QAMenu] Added missing `asChildPaneItem()` options to create items with values (MR #6)
 * [QAMenu] Allow to pass the root pane after initializing `QAMenu` with `setRootPane()` (MR #7)
-
+* [QAMenu] `QAMenu.Trigger` configuration is now backed by NSUserDefaults  (MR #7)
+* [QAMenu] Exposed configuration option `QAMenu.DismissBehavior` (MR #7)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 #### Enhancements
 
 * [QAMenu] Added missing `asChildPaneItem()` options to create items with values (MR #6)
+* [QAMenu] Allow to pass the root pane after initializing `QAMenu` with `setRootPane()` (MR #7)
+
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [QAMenu] Renamed parameter `isSearchable` to `isPaneSearchable` in `Item.asChildPaneItem()` (MR #6)
 * [QAMenu] Removed parameter `trigger` from `QAMenu()` in favor of `QAMenu.setTrigger()` (MR #7)
 * [QAMenu] Renamed `QAMenuDismissBehavior` to `QAMenu.DismissBehavior()` (MR #7)
+* [QAMenuCatalog] `QAMenu.Catalog.all()` requires now a `QAMenu` instance as parameter (MR #7)
 
 #### Enhancements
 
@@ -14,6 +15,7 @@
 * [QAMenu] Allow to pass the root pane after initializing `QAMenu` with `setRootPane()` (MR #7)
 * [QAMenu] `QAMenu.Trigger` configuration is now backed by NSUserDefaults  (MR #7)
 * [QAMenu] Exposed configuration option `QAMenu.DismissBehavior` (MR #7)
+* [QAMenuCatalog] Added group and items to be able to see and modify the QAMenu configuration (MR #7)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,23 @@
 
 #### Breaking Changes
 
-* [QAMenu] Renamed parameter `isSearchable` to `isPaneSearchable` in `Item.asChildPaneItem()` (MR #6)
-* [QAMenu] Removed parameter `trigger` from `QAMenu()` in favor of `QAMenu.setTrigger()` (MR #7)
-* [QAMenu] Renamed `QAMenuDismissBehavior` to `QAMenu.DismissBehavior()` (MR #7)
-* [QAMenuCatalog] `QAMenu.Catalog.all()` requires now a `QAMenu` instance as parameter (MR #7)
+* [QAMenu] Renamed parameter `isSearchable` to `isPaneSearchable` in `Item.asChildPaneItem()` (PR #6)
+* [QAMenu] Removed parameter `trigger` from `QAMenu()` in favor of `QAMenu.setTrigger()` (PR #7)
+* [QAMenu] Renamed `QAMenuDismissBehavior` to `QAMenu.DismissBehavior()` (PR #7)
+* [QAMenuCatalog] `QAMenu.Catalog.all()` requires now a `QAMenu` instance as parameter (PR #7)
 
 #### Enhancements
 
-* [QAMenu] Added missing `asChildPaneItem()` options to create items with values (MR #6)
-* [QAMenu] Allow to pass the root pane after initializing `QAMenu` with `setRootPane()` (MR #7)
-* [QAMenu] `QAMenu.Trigger` configuration is now backed by NSUserDefaults  (MR #7)
-* [QAMenu] Exposed configuration option `QAMenu.DismissBehavior` (MR #7)
-* [QAMenuCatalog] Added group and items to be able to see and modify the QAMenu configuration (MR #7)
+* [QAMenu] Added missing `asChildPaneItem()` options to create items with values (PR #6)
+* [QAMenu] Allow to pass the root pane after initializing `QAMenu` with `setRootPane()` (PR #7)
+* [QAMenu] `QAMenu.Trigger` configuration is now backed by NSUserDefaults  (PR #7)
+* [QAMenu] Exposed configuration option `QAMenu.DismissBehavior` (PR #7)
+* [QAMenuCatalog] Added group and items to be able to see and modify the QAMenu configuration (PR #7)
 
 #### Bug Fixes
 
-* [QAMenuUIKit] Fix not adapting layout when using split screen (MR #2)
-* [QAMenuUIKit] Update status bar color when the app is showing a modal screen (MR #2)
+* [QAMenuUIKit] Fix not adapting layout when using split screen (PR #2)
+* [QAMenuUIKit] Update status bar color when the app is showing a modal screen (PR #2)
 
 
 ## 0.2.0
@@ -31,7 +31,7 @@
 
 #### Enhancements
 
-* [QAMenuUIKit] Remove custom navigate to root pane button and use back button titles again (MR #1)
+* [QAMenuUIKit] Remove custom navigate to root pane button and use back button titles again (PR #1)
 
 #### Bug Fixes
 

--- a/Examples/Example-iOS/Sources/ExampleViewController.swift
+++ b/Examples/Example-iOS/Sources/ExampleViewController.swift
@@ -112,7 +112,11 @@ class ExampleViewController: UITableViewController {
     }
 
     private func setupShowcaseQAMenu() {
-        self.showcaseQAMenu = QAMenu(pane: ShowcaseItemsFactory.makeRootPane(), presenterType: QAMenuUIKitPresenter.self)
+        self.showcaseQAMenu = QAMenu(
+            identifier: "Simple QAMenu",
+            pane: ShowcaseItemsFactory.makeRootPane(),
+            presenterType: QAMenuUIKitPresenter.self
+        )
         if let presenter = self.showcaseQAMenu?.presenter as? QAMenuUIKitPresenter {
             presenter.ui.register(CustomPaneViewController.self, for: CustomPane.self)
         }
@@ -120,8 +124,14 @@ class ExampleViewController: UITableViewController {
 
     private func setupCatalogQAMenu() {
         self.catalogQAMenu = QAMenu(
-            pane: RootPane(title: .static("QA Menu Catalog"), groups: QAMenu.Catalog.all),
+            identifier: "Catalog QAMenu",
             presenterType: QAMenuUIKitPresenter.self
+        )
+        self.catalogQAMenu?.setRootPane(
+            RootPane(
+                title: .static("QA Menu Catalog"),
+                groups: QAMenu.Catalog.all(qaMenu: self.catalogQAMenu)
+            )
         )
     }
 
@@ -166,14 +176,18 @@ class ExampleViewController: UITableViewController {
                 }
             )
         ])
+        self.simpleProjectQAMenu = QAMenu(
+            identifier: "Simple QAMenu",
+            presenterType: QAMenuUIKitPresenter.self
+        )
         let groups: [Group] = [
             QAMenu.Catalog.AppInfo.group(),
             cacheGroup,
-            QAMenu.Catalog.Preferences.group()
+            QAMenu.Catalog.Preferences.group(),
+            QAMenu.Catalog.QAMenuConfiguration.group(qaMenu: self.simpleProjectQAMenu)
         ]
-        self.simpleProjectQAMenu = QAMenu(
-            pane: RootPane(title: .static("Simple Project"), groups: groups),
-            presenterType: QAMenuUIKitPresenter.self
+        self.simpleProjectQAMenu?.setRootPane(
+            RootPane(title: .static("Simple Project"), groups: groups)
         )
     }
 }

--- a/Examples/Example-iOS/Sources/ExampleViewController.swift
+++ b/Examples/Example-iOS/Sources/ExampleViewController.swift
@@ -127,6 +127,8 @@ class ExampleViewController: UITableViewController {
             identifier: "Catalog QAMenu",
             presenterType: QAMenuUIKitPresenter.self
         )
+        self.catalogQAMenu?.setTrigger([], mode: .initialValue)
+        self.catalogQAMenu?.setDismissBehavior(.resetImmediately, mode: .initialValue)
         self.catalogQAMenu?.setRootPane(
             RootPane(
                 title: .static("QA Menu Catalog"),

--- a/Examples/Pod-Integration/Pod-Integration-iOS/ViewController.swift
+++ b/Examples/Pod-Integration/Pod-Integration-iOS/ViewController.swift
@@ -18,7 +18,8 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.qaMenu = QAMenu(pane: RootPane(groups: QAMenu.Catalog.all), presenterType: QAMenuUIKitPresenter.self)
+        self.qaMenu = QAMenu(presenterType: QAMenuUIKitPresenter.self)
+        self.qaMenu?.setRootPane(RootPane(groups: QAMenu.Catalog.all(qaMenu: self.qaMenu)))
     }
 
     @IBAction private func showQAMenu(_ sender: Any) {

--- a/Examples/Pod-Integration/Podfile.lock
+++ b/Examples/Pod-Integration/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - QAMenu (0.1.0):
+  - QAMenu (0.2.0):
     - QAMenuUtils
-  - QAMenuCatalog (0.1.0):
+  - QAMenuCatalog (0.2.0):
     - QAMenu
-  - QAMenuUIKit (0.1.0):
+  - QAMenuUIKit (0.2.0):
     - QAMenu
-  - QAMenuUtils (0.1.0)
+  - QAMenuUtils (0.2.0)
 
 DEPENDENCIES:
   - QAMenu (from `../..`)
@@ -24,10 +24,10 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  QAMenu: 9dbc18fae328259da26d5f1494e13a4c2ea112da
-  QAMenuCatalog: b39b17b18002e9697ff784970b4da6c4010a10b7
-  QAMenuUIKit: ee79926c0ad022be07ee1ab5cd47652c90c8d982
-  QAMenuUtils: 8b29e285e6acc1ba46ee455e8c6dde0599f218d4
+  QAMenu: 4b2bdb83593499d55526f8a43440260c4af0027d
+  QAMenuCatalog: b8cfd5d4b1a9d41eb1140d63f06d428f4780b08c
+  QAMenuUIKit: eabc20413bcd35ca6fb46f395110034225514cf0
+  QAMenuUtils: 2f3670d4c7f8c951e2f3f29fb495c4acc37b70d2
 
 PODFILE CHECKSUM: c44ec374043f6477287d76b1a823a5ed8712e2ed
 

--- a/QAMenu.xcodeproj/project.pbxproj
+++ b/QAMenu.xcodeproj/project.pbxproj
@@ -60,6 +60,13 @@
 		A2172D2C25C9DF43009DC774 /* DisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2172D0325C9DF43009DC774 /* DisposableTests.swift */; };
 		A2172D2D25C9DF43009DC774 /* DisposeBagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2172D0425C9DF43009DC774 /* DisposeBagTests.swift */; };
 		A2172D7B25C9E4F0009DC774 /* RootPaneTests+Conversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2172D7A25C9E4F0009DC774 /* RootPaneTests+Conversions.swift */; };
+		A2172D9725C9EAD1009DC774 /* QAMenuConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2172D9525C9EAD1009DC774 /* QAMenuConfiguration.swift */; };
+		A2172D9825C9EAD1009DC774 /* QAMenuConfigurationStorable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2172D9625C9EAD1009DC774 /* QAMenuConfigurationStorable.swift */; };
+		A2172D9F25C9EAEC009DC774 /* Catalog+QAMenuConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2172D9E25C9EAEC009DC774 /* Catalog+QAMenuConfiguration.swift */; };
+		A2172DA725C9EB2D009DC774 /* QAMenuConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2172DA525C9EB2D009DC774 /* QAMenuConfigurationTests.swift */; };
+		A2172DA825C9EB2D009DC774 /* QAMenu+DismissBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2172DA625C9EB2D009DC774 /* QAMenu+DismissBehaviorTests.swift */; };
+		A2172DB925C9EE07009DC774 /* QAMenu+DismissBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2172DB825C9EE07009DC774 /* QAMenu+DismissBehavior.swift */; };
+		A2172DC025C9F38D009DC774 /* QAMenu+TriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2172DBF25C9F38D009DC774 /* QAMenu+TriggerTests.swift */; };
 		A2326E292558621500CB39E7 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2326E202558621500CB39E7 /* Logger.swift */; };
 		A2326E2A2558621500CB39E7 /* SwiftPrinter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2326E212558621500CB39E7 /* SwiftPrinter.swift */; };
 		A2326E2B2558621500CB39E7 /* SwiftDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2326E222558621500CB39E7 /* SwiftDateProvider.swift */; };
@@ -295,6 +302,13 @@
 		A2172D0425C9DF43009DC774 /* DisposeBagTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisposeBagTests.swift; sourceTree = "<group>"; };
 		A2172D0525C9DF43009DC774 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A2172D7A25C9E4F0009DC774 /* RootPaneTests+Conversions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RootPaneTests+Conversions.swift"; sourceTree = "<group>"; };
+		A2172D9525C9EAD1009DC774 /* QAMenuConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QAMenuConfiguration.swift; sourceTree = "<group>"; };
+		A2172D9625C9EAD1009DC774 /* QAMenuConfigurationStorable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QAMenuConfigurationStorable.swift; sourceTree = "<group>"; };
+		A2172D9E25C9EAEC009DC774 /* Catalog+QAMenuConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Catalog+QAMenuConfiguration.swift"; sourceTree = "<group>"; };
+		A2172DA525C9EB2D009DC774 /* QAMenuConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QAMenuConfigurationTests.swift; sourceTree = "<group>"; };
+		A2172DA625C9EB2D009DC774 /* QAMenu+DismissBehaviorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "QAMenu+DismissBehaviorTests.swift"; sourceTree = "<group>"; };
+		A2172DB825C9EE07009DC774 /* QAMenu+DismissBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "QAMenu+DismissBehavior.swift"; sourceTree = "<group>"; };
+		A2172DBF25C9F38D009DC774 /* QAMenu+TriggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "QAMenu+TriggerTests.swift"; sourceTree = "<group>"; };
 		A2217BB7255806ED0070FC68 /* QAMenuUtils-UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "QAMenuUtils-UnitTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2217BEF2558081E0070FC68 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A2326E202558621500CB39E7 /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
@@ -478,7 +492,10 @@
 				A2172CE625C9DF43009DC774 /* Data Structures */,
 				A2172CF925C9DF43009DC774 /* Dictionary+QAMenuTests.swift */,
 				A2172CFA25C9DF43009DC774 /* Utils */,
+				A2172DA625C9EB2D009DC774 /* QAMenu+DismissBehaviorTests.swift */,
+				A2172DBF25C9F38D009DC774 /* QAMenu+TriggerTests.swift */,
 				A2172CFE25C9DF43009DC774 /* QAMenu+LogTests.swift */,
+				A2172DA525C9EB2D009DC774 /* QAMenuConfigurationTests.swift */,
 				A2172D0025C9DF43009DC774 /* QAMenuTests.swift */,
 				A2172D0125C9DF43009DC774 /* Observable */,
 				A2172D0525C9DF43009DC774 /* Info.plist */,
@@ -668,8 +685,11 @@
 				A238A06B253C71AB0016BBD7 /* Utils */,
 				A28873E42516822A003528E5 /* Dictionary+QAMenu.swift */,
 				A28873E12516822A003528E5 /* QAMenu.swift */,
+				A2172DB825C9EE07009DC774 /* QAMenu+DismissBehavior.swift */,
 				A28873E22516822A003528E5 /* QAMenu+Log.swift */,
 				A28873E02516822A003528E5 /* QAMenu+Trigger.swift */,
+				A2172D9525C9EAD1009DC774 /* QAMenuConfiguration.swift */,
+				A2172D9625C9EAD1009DC774 /* QAMenuConfigurationStorable.swift */,
 				A28873E32516822A003528E5 /* QAMenuPresenter.swift */,
 			);
 			path = Public;
@@ -932,11 +952,12 @@
 		A2969E6025167D8600EA54D5 /* Public */ = {
 			isa = PBXGroup;
 			children = (
-				A2969E6125167D8600EA54D5 /* Catalog+AppInfo.swift */,
 				A2969E6225167D8600EA54D5 /* Catalog.Device+Accessibility.swift */,
 				A2969E6525167D8600EA54D5 /* Catalog.Device+Locale.swift */,
+				A2969E6125167D8600EA54D5 /* Catalog+AppInfo.swift */,
 				A2969E6325167D8600EA54D5 /* Catalog+Device.swift */,
 				A2969E6425167D8600EA54D5 /* Catalog+Preferences.swift */,
+				A2172D9E25C9EAEC009DC774 /* Catalog+QAMenuConfiguration.swift */,
 				A2969E6625167D8600EA54D5 /* QAMenu+Catalog.swift */,
 			);
 			path = Public;
@@ -1503,8 +1524,11 @@
 				A249DE60258FA0E2002AEC41 /* DialogTrigger.swift in Sources */,
 				A28873E92516822A003528E5 /* Searchable.swift in Sources */,
 				A238A06D253C71AC0016BBD7 /* Dynamic.swift in Sources */,
+				A2172D9825C9EAD1009DC774 /* QAMenuConfigurationStorable.swift in Sources */,
 				A249DE66258FA7A9002AEC41 /* NavigationTrigger.swift in Sources */,
 				A249DE46258E5CAD002AEC41 /* PickableItem.swift in Sources */,
+				A2172D9725C9EAD1009DC774 /* QAMenuConfiguration.swift in Sources */,
+				A2172DB925C9EE07009DC774 /* QAMenu+DismissBehavior.swift in Sources */,
 				A2BEC0E4257BFD5B0005EFDF /* PaneRepresentable.swift in Sources */,
 				A2EA8C9825867E25008F18DF /* PickerGroup.swift in Sources */,
 				A28873F22516822A003528E5 /* BoolItem.swift in Sources */,
@@ -1541,6 +1565,8 @@
 				A2172D0F25C9DF43009DC774 /* MockPane.swift in Sources */,
 				A2172D1F25C9DF43009DC774 /* PickableStringItemTests.swift in Sources */,
 				A2172D2225C9DF43009DC774 /* BoolItemTests.swift in Sources */,
+				A2172DA725C9EB2D009DC774 /* QAMenuConfigurationTests.swift in Sources */,
+				A2172DA825C9EB2D009DC774 /* QAMenu+DismissBehaviorTests.swift in Sources */,
 				A2172D1525C9DF43009DC774 /* SearchableTests.swift in Sources */,
 				A2172D1825C9DF43009DC774 /* RootPaneTests.swift in Sources */,
 				A2172D1225C9DF43009DC774 /* MockPickableItem.swift in Sources */,
@@ -1553,6 +1579,7 @@
 				A2172D2A25C9DF43009DC774 /* QAMenuTests.swift in Sources */,
 				A2172D1625C9DF43009DC774 /* PickerGroupTests.swift in Sources */,
 				A2172D1B25C9DF43009DC774 /* PickableItemTests.swift in Sources */,
+				A2172DC025C9F38D009DC774 /* QAMenu+TriggerTests.swift in Sources */,
 				A2172D1E25C9DF43009DC774 /* PickerGroupTests+Conversions.swift in Sources */,
 				A2172D1425C9DF43009DC774 /* MockItem.swift in Sources */,
 				A2172D2125C9DF43009DC774 /* ChildPaneItemTests.swift in Sources */,
@@ -1607,6 +1634,7 @@
 				A2969E6D25167D8600EA54D5 /* Catalog.Device+Locale.swift in Sources */,
 				A2969E6A25167D8600EA54D5 /* Catalog.Device+Accessibility.swift in Sources */,
 				A2969E6925167D8600EA54D5 /* Catalog+AppInfo.swift in Sources */,
+				A2172D9F25C9EAEC009DC774 /* Catalog+QAMenuConfiguration.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/QAMenu/Public/Data Structure/PickerGroup.swift
+++ b/Sources/QAMenu/Public/Data Structure/PickerGroup.swift
@@ -68,7 +68,7 @@ open class PickerGroup: Group, DialogTrigger, NavigationTrigger {
         title: Dynamic<String?>? = nil,
         options: [PickableItem],
         footerText: Dynamic<String?>? = nil,
-        onPickedOption: @escaping ((_ item: PickableItem, _ result: ((PickResult) -> Void)) -> Void)
+        onPickedOption: @escaping (_ item: PickableItem, _ result: ((PickResult) -> Void)) -> Void
     ) {
         self.title = title
         self.options = options

--- a/Sources/QAMenu/Public/QAMenu+DismissBehavior.swift
+++ b/Sources/QAMenu/Public/QAMenu+DismissBehavior.swift
@@ -1,12 +1,12 @@
 //
-//  QAMenu+Trigger.swift
+//  QAMenu+DismissBehavior.swift
 //
-//  Created by Hans Seiffert on 30.05.20.
+//  Created by Hans Seiffert on 31.12.21.
 //
 //  ---
 //  MIT License
 //
-//  Copyright © 2020 Hans Seiffert
+//  Copyright © 2021 Hans Seiffert
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -28,39 +28,49 @@
 
 import Foundation
 
-public extension QAMenu {
+// MARK: - QAMenu + DismissBehavior
 
-    enum Trigger: CaseIterable {
-        case shake
+extension QAMenu {
 
-        public init?(stringValue: String) {
-            guard let instance = Self.allCases.first(where: { $0.key == stringValue }) else {
-                return nil
-            }
-            self = instance
-        }
-
-        public var key: String {
-            switch self {
-            case .shake:
-                return "shake"
-            }
-        }
+    public enum DismissBehavior: Equatable {
+        case resetImmediately
+        case resetAfter(TimeInterval)
+        case neverReset
     }
 }
 
-// MARK: Array<Trigger> + QAMenuConfigurationItemStorable
+// MARK: - DismissBehavior + QAMenuConfigurationItemStorable
 
-extension Array: QAMenuConfigurationItemStorable where Element == QAMenu.Trigger {
+extension QAMenu.DismissBehavior: QAMenuConfigurationItemStorable {
 
     public init?(stringValue: String) {
-        let components = stringValue.components(separatedBy: ",")
-        self = components.compactMap { QAMenu.Trigger(stringValue: $0) }
+        guard let timerInterval = TimeInterval(stringValue) else {
+            return nil
+        }
+        switch timerInterval {
+        case -1:
+            self = .neverReset
+        case 0:
+            self = .resetImmediately
+        case 1...:
+            self = .resetAfter(timerInterval)
+        default:
+            return nil
+        }
+    }
+
+    public var timerInterval: TimeInterval {
+        switch self {
+        case .resetImmediately:
+            return 0
+        case .resetAfter(let timeInterval):
+            return timeInterval
+        case .neverReset:
+            return -1
+        }
     }
 
     public var toString: String {
-        return self
-            .map { $0.key }
-            .joined(separator: ",")
+        return String(self.timerInterval)
     }
 }

--- a/Sources/QAMenu/Public/QAMenu.swift
+++ b/Sources/QAMenu/Public/QAMenu.swift
@@ -33,6 +33,8 @@ open class QAMenu {
 
     // MARK: - Properties (Public)
 
+    public let identifier: String
+
     open var trigger: Trigger
 
     open var onDidAppear: (() -> Void)?
@@ -47,23 +49,33 @@ open class QAMenu {
 
     public static var instances = [WeakBox<QAMenu>]()
 
-    open private(set) var pane: RootPane
+    open private(set) var pane: RootPane?
 
     // MARK: - Initialization
 
     public init(
-        pane: RootPane,
+        identifier: String = "QAMenu",
+        pane: RootPane? = nil,
         trigger: Trigger = .shake,
         presenterType: QAMenuPresenter.Type
     ) {
-        self.pane = pane
         self.trigger = trigger
+        self.identifier = identifier
         self.presenterType = presenterType
         Self.instances.append(WeakBox(self))
+        if let pane = pane {
+            self.setRootPane(pane)
+        }
     }
 
     deinit {
         Logger.verbose("deinit")
+    }
+
+    // MARK: - Setter
+
+    public func setRootPane(_ pane: RootPane) {
+        self.pane = pane
     }
 
     // MARK: -

--- a/Sources/QAMenu/Public/QAMenuConfiguration.swift
+++ b/Sources/QAMenu/Public/QAMenuConfiguration.swift
@@ -1,0 +1,108 @@
+//
+//  QAMenuConfigurationItem.swift
+//
+//  Created by Hans Seiffert on 30.01.21.
+//
+//  ---
+//  MIT License
+//
+//  Copyright © 2021 Hans Seiffert
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//
+
+import Foundation
+import QAMenuUtils
+
+// MARK: - QAMenuConfigurationItemSetterMode
+
+public enum QAMenuConfigurationItemSetterMode {
+    case initialValue
+    case forceReplace
+}
+
+// MARK: - QAMenuConfigurationStorageProvider
+
+public protocol QAMenuConfigurationStorageProvider {
+    func set(_ value: Any?, forKey defaultName: String)
+    func string(forKey defaultName: String) -> String?
+}
+
+// MARK: - QAMenuConfigurationItem
+
+@propertyWrapper
+public struct QAMenuConfigurationItem<Value: QAMenuConfigurationItemStorable> {
+    internal let key: String
+    internal let defaultValue: Value
+    internal var configurationStorage: QAMenuConfigurationStorageProvider?
+
+    public init(
+        key: String,
+        defaultValue: Value
+    ) {
+        self.key = key
+        self.defaultValue = defaultValue
+    }
+
+    public var wrappedValue: Value {
+        get {
+            guard let configurationStorage = self.configurationStorage else {
+                // swiftlint:disable:next line_length
+                Logger.error("You need to provide `configurationStorage` before accessing the wrapped value of \(self)! The default value will be returned instead.")
+                return defaultValue
+            }
+            // Read value from UserDefaults
+            if let rawValue = configurationStorage.string(forKey: self.key), let value = Value(stringValue: rawValue) {
+                return value
+            } else {
+                return defaultValue
+            }
+        }
+        set {
+            // Set value to UserDefaults
+            configurationStorage?.set(newValue.toString, forKey: self.key)
+        }
+    }
+
+    internal mutating func setup(for qaMenu: QAMenu) {
+        // Inject the configuration storage manually as property wrappers don't allow the usage of `self` yet
+        let userDefaults = UserDefaults(
+            suiteName: "\(qaMenu.identifier) configuration"
+        ) ?? UserDefaults.standard
+        self.configurationStorage = userDefaults
+    }
+
+    internal var wasValueInitiallySet: Bool {
+        return self.configurationStorage?.string(forKey: self.key) != nil
+    }
+
+    internal mutating func updateValue(with newValue: Value, mode: QAMenuConfigurationItemSetterMode) {
+        switch mode {
+        case .initialValue:
+            if !self.wasValueInitiallySet {
+                self.wrappedValue = newValue
+            }
+        case .forceReplace:
+            self.wrappedValue = newValue
+        }
+    }
+}
+
+// MARK: - UserDefaults + QAMenuConfigurationStorageProvider
+
+extension UserDefaults: QAMenuConfigurationStorageProvider {}

--- a/Sources/QAMenu/Public/QAMenuConfigurationStorable.swift
+++ b/Sources/QAMenu/Public/QAMenuConfigurationStorable.swift
@@ -1,12 +1,12 @@
 //
-//  QAMenu+Trigger.swift
+//  QAMenuConfigurationItemStorable.swift
 //
-//  Created by Hans Seiffert on 30.05.20.
+//  Created by Hans Seiffert on 30.01.21.
 //
 //  ---
 //  MIT License
 //
-//  Copyright © 2020 Hans Seiffert
+//  Copyright © 2021 Hans Seiffert
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -27,40 +27,11 @@
 //
 
 import Foundation
+import QAMenuUtils
 
-public extension QAMenu {
+public protocol QAMenuConfigurationItemStorable {
 
-    enum Trigger: CaseIterable {
-        case shake
+    init?(stringValue: String)
 
-        public init?(stringValue: String) {
-            guard let instance = Self.allCases.first(where: { $0.key == stringValue }) else {
-                return nil
-            }
-            self = instance
-        }
-
-        public var key: String {
-            switch self {
-            case .shake:
-                return "shake"
-            }
-        }
-    }
-}
-
-// MARK: Array<Trigger> + QAMenuConfigurationItemStorable
-
-extension Array: QAMenuConfigurationItemStorable where Element == QAMenu.Trigger {
-
-    public init?(stringValue: String) {
-        let components = stringValue.components(separatedBy: ",")
-        self = components.compactMap { QAMenu.Trigger(stringValue: $0) }
-    }
-
-    public var toString: String {
-        return self
-            .map { $0.key }
-            .joined(separator: ",")
-    }
+    var toString: String { get }
 }

--- a/Sources/QAMenu/Public/QAMenuPresenter.swift
+++ b/Sources/QAMenu/Public/QAMenuPresenter.swift
@@ -28,14 +28,6 @@
 
 import Foundation
 
-// MARK: - QAMenuDismissBehavior
-
-public enum QAMenuDismissBehavior: Equatable {
-    case resetImmediately
-    case resetAfter(TimeInterval)
-    case neverReset
-}
-
 // MARK: - QAMenuState
 
 public enum QAMenuState {
@@ -47,9 +39,9 @@ public enum QAMenuState {
 
 public protocol QAMenuPresenter: AnyObject {
 
-    var dismissBehavior: QAMenuDismissBehavior { get }
+    var dismissBehavior: QAMenu.DismissBehavior { get set }
 
-    init(qaMenu: QAMenu)
+    init(qaMenu: QAMenu, dismissBehavior: QAMenu.DismissBehavior)
 
     func toggleVisibility(completion: @escaping (_ newState: QAMenuState) -> Void)
     func show(completion: @escaping () -> Void)

--- a/Sources/QAMenuCatalog/Public/Catalog+AppInfo.swift
+++ b/Sources/QAMenuCatalog/Public/Catalog+AppInfo.swift
@@ -31,7 +31,7 @@ import QAMenu
 
 public extension QAMenu.Catalog {
 
-    enum AppInfo: CatalogGroup {
+    enum AppInfo {
 
         public static var all: [Group] {
             return [

--- a/Sources/QAMenuCatalog/Public/Catalog+Device.swift
+++ b/Sources/QAMenuCatalog/Public/Catalog+Device.swift
@@ -31,7 +31,7 @@ import QAMenu
 
 public extension QAMenu.Catalog {
 
-    enum Device: CatalogGroup {
+    enum Device {
 
         public static var all: [Group] {
             return [

--- a/Sources/QAMenuCatalog/Public/Catalog+Preferences.swift
+++ b/Sources/QAMenuCatalog/Public/Catalog+Preferences.swift
@@ -31,7 +31,7 @@ import QAMenu
 
 public extension QAMenu.Catalog {
 
-    enum Preferences: CatalogGroup {
+    enum Preferences {
 
         public static var all: [Group] {
             return [

--- a/Sources/QAMenuCatalog/Public/Catalog+QAMenuConfiguration.swift
+++ b/Sources/QAMenuCatalog/Public/Catalog+QAMenuConfiguration.swift
@@ -1,0 +1,154 @@
+//
+//  Catalog+QAMenuConfigurationItem.swift
+//
+//  Created by Hans Seiffert on 30.01.21.
+//
+//  ---
+//  MIT License
+//
+//  Copyright © 2021 Hans Seiffert
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//
+
+import Foundation
+import QAMenu
+
+public extension QAMenu.Catalog {
+
+    enum QAMenuConfiguration {
+
+        public static func all(
+            qaMenu: QAMenu?
+        ) -> [Group] {
+            return [
+                group(
+                    qaMenu: qaMenu
+                )
+            ]
+        }
+
+        public static func group(
+            title: String = "QAMenu Configuration",
+            qaMenu: QAMenu?
+        ) -> ItemGroup {
+            let dismissBehaviorPicker = Items.dismissBehaviorPicker(
+                qaMenu: qaMenu,
+                shouldDismiss: true
+            )
+            .asChildPaneItem(
+                value: .computed({ [weak qaMenu] in
+                    qaMenu?.dismissBehavior.description
+                }),
+                layoutType: .static(.vertical(.autoGrow))
+            )
+
+            return ItemGroup(
+                title: .static(title),
+                items: [
+                    Items.triggerBoolItem(qaMenu: qaMenu),
+                    dismissBehaviorPicker
+                ]
+            )
+        }
+
+        public enum Items {
+
+            public static func triggerBoolItem(qaMenu: QAMenu?) -> BoolItem {
+                return BoolItem(
+                    title: .static("Shake to open / close"),
+                    value: .computed({ [weak qaMenu] in
+                        qaMenu?.trigger.contains(.shake) ?? false
+                    }),
+                    onValueChange: { [weak qaMenu]  (newValue, _, result) in
+                        guard let qaMenu = qaMenu else {
+                            result(.failure("QAMenu instance doesn't exist anymore"))
+                            return
+                        }
+                        if newValue {
+                            var trigger = qaMenu.trigger
+                            trigger.append(.shake)
+                            qaMenu.setTrigger(trigger, mode: .forceReplace)
+                        } else {
+                            var trigger = qaMenu.trigger
+                            trigger.removeAll(where: { $0 == .shake })
+                            qaMenu.setTrigger(trigger, mode: .forceReplace)
+                        }
+                        result(.success)
+                    }
+                )
+            }
+
+            public static func dismissBehaviorPicker(
+                qaMenu: QAMenu?,
+                shouldDismiss: Bool
+            ) -> PickerGroup {
+                let options = [
+                    QAMenu.DismissBehavior.resetImmediately.asPickableStringItem(qaMenu: qaMenu),
+                    QAMenu.DismissBehavior.resetAfter(30).asPickableStringItem(qaMenu: qaMenu),
+                    QAMenu.DismissBehavior.neverReset.asPickableStringItem(qaMenu: qaMenu)
+                ]
+                return PickerGroup(
+                    title: .static("Close behavior"),
+                    options: options,
+                    footerText: .static("A reset navigates back to the root pane."),
+                    onPickedOption: { (item, result) in
+                        switch item.identifier() {
+                        case "\(QAMenu.DismissBehavior.resetImmediately)":
+                            qaMenu?.setDismissBehavior(.resetImmediately, mode: .forceReplace)
+                        case "\(QAMenu.DismissBehavior.resetAfter(30))":
+                            qaMenu?.setDismissBehavior(.resetAfter(30), mode: .forceReplace)
+                        case "\(QAMenu.DismissBehavior.neverReset)":
+                            qaMenu?.setDismissBehavior(.neverReset, mode: .forceReplace)
+                        default:
+                            result(.failure("Couldn't map identifier to QAMenu.DismissBehavior"))
+                            return
+                        }
+                        result(.success(shouldDismiss: shouldDismiss))
+                    }
+                )
+            }
+        }
+    }
+}
+
+// MARK: - QAMenu.DismissBehavior + Catalog
+
+private extension QAMenu.DismissBehavior {
+
+    var description: String {
+        switch self {
+        case .resetImmediately:
+            return "Reset Immediately"
+        case .resetAfter:
+            return "Reset after 30 seconds"
+        case .neverReset:
+            return "Never reset"
+        }
+    }
+
+    func asPickableStringItem(qaMenu: QAMenu?) -> PickableStringItem {
+        return PickableStringItem(
+            identifier: .static("\(self)"),
+            title: .static(self.description),
+            isSelected: .computed({ [weak qaMenu] in
+                return qaMenu?.dismissBehavior == self
+            })
+        )
+    }
+}

--- a/Sources/QAMenuCatalog/Public/Catalog.Device+Accessibility.swift
+++ b/Sources/QAMenuCatalog/Public/Catalog.Device+Accessibility.swift
@@ -34,7 +34,7 @@ import QAMenu
 
 public extension QAMenu.Catalog.Device {
 
-    enum Accessibility: CatalogGroup {
+    enum Accessibility {
 
         public static var all: [Group] {
             return [

--- a/Sources/QAMenuCatalog/Public/Catalog.Device+Locale.swift
+++ b/Sources/QAMenuCatalog/Public/Catalog.Device+Locale.swift
@@ -31,7 +31,7 @@ import QAMenu
 
 public extension QAMenu.Catalog.Device {
 
-    enum Locale: CatalogGroup {
+    enum Locale {
 
         public static var all: [Group] {
             return [

--- a/Sources/QAMenuCatalog/Public/QAMenu+Catalog.swift
+++ b/Sources/QAMenuCatalog/Public/QAMenu+Catalog.swift
@@ -29,20 +29,16 @@
 import Foundation
 import QAMenu
 
-public protocol CatalogGroup {
-
-    static var all: [Group] { get }
-}
-
 public extension QAMenu {
 
-    enum Catalog: CatalogGroup {
+    enum Catalog {
 
-        public static var all: [Group] {
+        public static func all(qaMenu: QAMenu?) -> [Group] {
             return [
                 AppInfo.all,
                 Preferences.all,
-                Device.all
+                Device.all,
+                QAMenuConfiguration.all(qaMenu: qaMenu)
             ].flatMap { $0 }
         }
     }

--- a/Sources/QAMenuUIKit/Internal/QAMenuLifecycleManager.swift
+++ b/Sources/QAMenuUIKit/Internal/QAMenuLifecycleManager.swift
@@ -34,7 +34,7 @@ internal class QAMenuLifecycleManager {
 
     // MARK: - Properties (Internal)
 
-    internal var dismissBehavior: QAMenuDismissBehavior
+    internal var dismissBehavior: QAMenu.DismissBehavior
 
     internal private(set) weak var presenter: QAMenuPresenter?
 
@@ -46,7 +46,7 @@ internal class QAMenuLifecycleManager {
 
     internal init(
         presenter: QAMenuPresenter,
-        dismissBehavior: QAMenuDismissBehavior
+        dismissBehavior: QAMenu.DismissBehavior
     ) {
         self.presenter = presenter
         self.dismissBehavior = dismissBehavior
@@ -60,7 +60,10 @@ internal class QAMenuLifecycleManager {
             DispatchQueue.main.async(execute: self.makeResetWorkItem(forId: self.lifecycleId))
         case .resetAfter(let duration):
             let targetLifecycleId = self.lifecycleId
-            DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: self.makeResetWorkItem(forId: targetLifecycleId))
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + duration,
+                execute: self.makeResetWorkItem(forId: targetLifecycleId)
+            )
         case .neverReset:
             break
         }

--- a/Sources/QAMenuUIKit/Public/UI/QAMenuUIKitPresenter.swift
+++ b/Sources/QAMenuUIKit/Public/UI/QAMenuUIKitPresenter.swift
@@ -83,8 +83,12 @@ open class QAMenuUIKitPresenter: QAMenuPresenter {
             Logger.verbose("Trying to setup the qa menu window, but the qa menu object is nil")
             return
         }
-        let paneRepresentable = self.ui.retrieve(for: type(of: qaMenu.pane))
-        let uiRepresentation = paneRepresentable.make(for: qaMenu.pane, in: qaMenu)
+        guard let rootPane = qaMenu.pane else {
+            Logger.error("You need to set a root pane before using qa menu!")
+            return
+        }
+        let paneRepresentable = self.ui.retrieve(for: type(of: rootPane))
+        let uiRepresentation = paneRepresentable.make(for: rootPane, in: qaMenu)
 
         let navigationController = UINavigationController(rootViewController: uiRepresentation)
 

--- a/Sources/QAMenuUIKit/Public/UI/QAMenuUIKitPresenter.swift
+++ b/Sources/QAMenuUIKit/Public/UI/QAMenuUIKitPresenter.swift
@@ -35,7 +35,7 @@ open class QAMenuUIKitPresenter: QAMenuPresenter {
 
     // MARK: - Properties (Public)
 
-    open var dismissBehavior: QAMenuDismissBehavior {
+    open var dismissBehavior: QAMenu.DismissBehavior {
         didSet {
             self.lifecycleManager.dismissBehavior = dismissBehavior
         }
@@ -71,9 +71,12 @@ open class QAMenuUIKitPresenter: QAMenuPresenter {
 
     // MARK: - Initialization
 
-    public required init(qaMenu: QAMenu) {
+    public required init(
+        qaMenu: QAMenu,
+        dismissBehavior: QAMenu.DismissBehavior
+    ) {
         self.qaMenu = qaMenu
-        self.dismissBehavior = .resetAfter(30)
+        self.dismissBehavior = dismissBehavior
         self.lifecycleManager.dismissBehavior = self.dismissBehavior
         self.registerDefaultElements()
     }

--- a/Tests/QAMenu-UnitTests/Mocks/MockQAMenuPresenter.swift
+++ b/Tests/QAMenu-UnitTests/Mocks/MockQAMenuPresenter.swift
@@ -39,10 +39,10 @@ class MockQAMenuPresenter: QAMenuPresenter {
     let _show = ObservableEvent<Void>()
     let _hide = ObservableEvent<Void>()
 
-    var dismissBehavior: QAMenuDismissBehavior
+    var dismissBehavior: QAMenu.DismissBehavior
 
-    required init(qaMenu: QAMenu) {
-        self.dismissBehavior = .neverReset
+    required init(qaMenu: QAMenu, dismissBehavior: QAMenu.DismissBehavior = .neverReset) {
+        self.dismissBehavior = dismissBehavior
     }
 
     func toggleVisibility(completion: @escaping (QAMenuState) -> Void) {

--- a/Tests/QAMenu-UnitTests/QAMenu+DismissBehaviorTests.swift
+++ b/Tests/QAMenu-UnitTests/QAMenu+DismissBehaviorTests.swift
@@ -1,0 +1,122 @@
+//
+//  QAMenu+DismissBehaviorTests.swift
+//
+//  Created by Hans Seiffert on 31.01.21.
+//
+//  ---
+//  MIT License
+//
+//  Copyright © 2021 Hans Seiffert
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//
+
+import XCTest
+import QAMenu
+
+class QAMenuDismissBehaviorTests: XCTestCase {
+
+    // MARK: - init
+
+    func test_init_whenGivenMinus1AsString_setsSelfToNeverReset() throws {
+        let sut = QAMenu.DismissBehavior(stringValue: "-1")
+        XCTAssertEqual(sut, QAMenu.DismissBehavior.neverReset)
+    }
+
+    func test_init_whenGiven0AsString_setsSelfToResetImmediately() throws {
+        let sut = QAMenu.DismissBehavior(stringValue: "0")
+        XCTAssertEqual(sut, QAMenu.DismissBehavior.resetImmediately)
+    }
+
+    func test_init_whenGiven1AsString_setsSelfToResetAfter1() throws {
+        let sut = QAMenu.DismissBehavior(stringValue: "1")
+        XCTAssertEqual(sut, QAMenu.DismissBehavior.resetAfter(1))
+    }
+
+    func test_init_whenGiven30AsString_setsSelfToResetAfter30() throws {
+        let sut = QAMenu.DismissBehavior(stringValue: "30.0")
+        XCTAssertEqual(sut, QAMenu.DismissBehavior.resetAfter(30))
+    }
+
+    func test_init_whenGivenMinus2AsString_returnsNil() throws {
+        let sut = QAMenu.DismissBehavior(stringValue: "-2")
+        XCTAssertNil(sut)
+    }
+
+    func test_init_whenGivenEmptyString_returnsNil() throws {
+        let sut = QAMenu.DismissBehavior(stringValue: "")
+        XCTAssertNil(sut)
+    }
+
+    func test_init_whenGivenStringWithCharacters_returnsNil() throws {
+        let sut = QAMenu.DismissBehavior(stringValue: "s1.0")
+        XCTAssertNil(sut)
+    }
+
+    // MARK: - timerInterval
+
+    func test_timerInterval_whenSelfIsNeverReset_returnsMinus1() throws {
+        let sut = QAMenu.DismissBehavior.neverReset
+        let timerInterval = sut.timerInterval
+        XCTAssertEqual(timerInterval, -1)
+    }
+
+    func test_timerInterval_whenSelfIsResetImmediately_returns0() throws {
+        let sut = QAMenu.DismissBehavior.resetImmediately
+        let timerInterval = sut.timerInterval
+        XCTAssertEqual(timerInterval, 0)
+    }
+
+    func test_timerInterval_whenSelfIsResetAfter1Seconds_returns1() throws {
+        let sut = QAMenu.DismissBehavior.resetAfter(1)
+        let timerInterval = sut.timerInterval
+        XCTAssertEqual(timerInterval, 1)
+    }
+
+    func test_timerInterval_whenSelfIsResetAfter30Seconds_returns30() throws {
+        let sut = QAMenu.DismissBehavior.resetAfter(30)
+        let timerInterval = sut.timerInterval
+        XCTAssertEqual(timerInterval, 30)
+    }
+
+    // MARK: - toString
+
+    func test_toString_whenSelfIsNeverReset_returnsMinus1AsString() throws {
+        let sut = QAMenu.DismissBehavior.neverReset
+        let string = sut.toString
+        XCTAssertEqual(string, "-1.0")
+    }
+
+    func test_timerInterval_whenSelfIsResetImmediately_returns0AsString() throws {
+        let sut = QAMenu.DismissBehavior.resetImmediately
+        let string = sut.toString
+        XCTAssertEqual(string, "0.0")
+    }
+
+    func test_timerInterval_whenSelfIsResetAfter1Seconds_returns1AsString() throws {
+        let sut = QAMenu.DismissBehavior.resetAfter(1)
+        let string = sut.toString
+        XCTAssertEqual(string, "1.0")
+    }
+
+    func test_timerInterval_whenSelfIsResetAfter30Seconds_returns30AsString() throws {
+        let sut = QAMenu.DismissBehavior.resetAfter(30)
+        let string = sut.toString
+        XCTAssertEqual(string, "30.0")
+    }
+}

--- a/Tests/QAMenu-UnitTests/QAMenu+TriggerTests.swift
+++ b/Tests/QAMenu-UnitTests/QAMenu+TriggerTests.swift
@@ -1,0 +1,110 @@
+//
+//  QAMenu+TriggerTests.swift
+//
+//  Created by Hans Seiffert on 31.01.21.
+//
+//  ---
+//  MIT License
+//
+//  Copyright © 2021 Hans Seiffert
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//
+
+import XCTest
+import QAMenu
+
+class QAMenuTriggerTests: XCTestCase {
+
+    // MARK: - init
+
+    func test_init_whenGivenEmptyString_returnsNil() throws {
+        let sut = QAMenu.Trigger(stringValue: "")
+        XCTAssertNil(sut)
+    }
+
+    func test_init_whenGivenShakeAsString_returnsShakeTrigger() throws {
+        let sut = QAMenu.Trigger(stringValue: "shake")
+        XCTAssertEqual(sut, .shake)
+    }
+
+    func test_init_whenGivenRandomStringWithCharacters_returnsNil() throws {
+        let sut = QAMenu.Trigger(stringValue: "s1.0")
+        XCTAssertNil(sut)
+    }
+
+    // MARK: - key
+
+    func test_key_whenSelfIsShake_returnsShake() throws {
+        let sut = QAMenu.Trigger.shake
+        let key = sut.key
+        XCTAssertEqual(key, "shake")
+    }
+
+    // MARK: - [Trigger] + QAMenuConfigurationItemStorable
+
+    // MARK: - init
+
+    func test_init_whenGivenEmptyString_setsSelfToNotrigger() throws {
+        let sut = [QAMenu.Trigger](stringValue: "")
+        XCTAssertEqual(sut, [])
+    }
+
+    func test_init_whenGivenShakeAsString_setsSelfToShake() throws {
+        let sut = [QAMenu.Trigger](stringValue: "shake")
+        XCTAssertEqual(sut, [.shake])
+    }
+
+    func test_init_whenGivenTwoTriggersAsString_setsSelfToBoth() throws {
+        let sut = [QAMenu.Trigger](stringValue: "shake,shake")
+        XCTAssertEqual(sut, [.shake, .shake])
+    }
+
+    func test_init_whenGivenTriggerWithTypoAsString_setsSelfToNoTrigger() throws {
+        let sut = [QAMenu.Trigger](stringValue: "shaker")
+        XCTAssertEqual(sut, [])
+    }
+
+    func test_init_whenGivenRandomString_setsSelfToNoTrigger() throws {
+        let sut = [QAMenu.Trigger](stringValue: "abcdedf")
+        XCTAssertEqual(sut, [])
+    }
+
+    // MARK: - toString
+
+    func test_toString_whenSelfIsEmpty_returnsExpectedString() throws {
+        let sut = [QAMenu.Trigger]()
+        let string = sut.toString
+        XCTAssertEqual(string, "")
+    }
+
+    func test_toString_whenSelfIsShake_returnsExpectedString() throws {
+        let sut = [QAMenu.Trigger.shake]
+        let string = sut.toString
+        XCTAssertEqual(string, "shake")
+    }
+
+    func test_toString_whenSelfHasTwoTriggers_returnsExpectedString() throws {
+        let sut = [
+            QAMenu.Trigger.shake,
+            QAMenu.Trigger.shake
+        ]
+        let string = sut.toString
+        XCTAssertEqual(string, "shake,shake")
+    }
+}

--- a/Tests/QAMenu-UnitTests/QAMenuConfigurationTests.swift
+++ b/Tests/QAMenu-UnitTests/QAMenuConfigurationTests.swift
@@ -1,0 +1,201 @@
+//
+//  QAMenuConfigurationItemTests.swift
+//
+//  Created by Hans Seiffert on 31.01.21.
+//
+//  ---
+//  MIT License
+//
+//  Copyright © 2021 Hans Seiffert
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// 
+
+import XCTest
+@testable import QAMenu
+
+class QAMenuConfigurationItemTests: XCTestCase {
+
+    private class Wrapper {
+
+        @QAMenuConfigurationItem(key: "key", defaultValue: "default")
+        var sut: String
+
+        let qaMenu = QAMenu(
+            identifier: "unittest",
+            pane: RootPane(items: []),
+            presenterType: MockQAMenuPresenter.self
+        )
+
+        // Expose property wrapper properties
+
+        var key: String {
+            return self._sut.key
+        }
+
+        var defaultValue: String {
+            return self._sut.defaultValue
+        }
+
+        var configurationStorage: QAMenuConfigurationStorageProvider? {
+            return self._sut.configurationStorage
+        }
+
+        // Expose property wrapper methods
+
+        func setup(for qaMenu: QAMenu) {
+            self._sut.setup(for: qaMenu)
+        }
+
+        var wasValueInitiallySet: Bool {
+            return self._sut.wasValueInitiallySet
+        }
+
+        func updateValue(with newValue: String, mode: QAMenuConfigurationItemSetterMode) {
+            self._sut.updateValue(with: newValue, mode: mode)
+        }
+    }
+
+    private var wrapper: Wrapper!
+
+    override func setUpWithError() throws {
+        self.wrapper = Wrapper()
+    }
+
+    override func tearDownWithError() throws {
+        UserDefaults().removePersistentDomain(forName: "unittest configuration")
+        UserDefaults().removePersistentDomain(forName: "QAMenu configuration")
+        self.wrapper = nil
+    }
+
+    func test_init_doesNotAddConfigurationStorage() throws {
+        XCTAssertNil(self.wrapper.configurationStorage)
+    }
+
+    // MARK: - setup
+
+    func test_setup_addsConfigurationStorage() throws {
+        XCTAssertNil(self.wrapper.configurationStorage)
+
+        self.wrapper.setup(for: self.wrapper.qaMenu)
+
+        XCTAssertNotNil(self.wrapper.configurationStorage)
+    }
+
+    // MARK: - wrappedValue
+
+    func test_wrappedValue_beforeSetupWasCalled_isDefaultValue() throws {
+        self.wrapper.sut = "value"
+
+        XCTAssertEqual(self.wrapper.sut, "default")
+    }
+
+    func test_wrappedValue_isValue() throws {
+        self.wrapper.setup(for: self.wrapper.qaMenu)
+
+        self.wrapper.sut = "value"
+
+        XCTAssertEqual(self.wrapper.sut, "value")
+    }
+
+    func test_wrappedValue_whenSet_setsValueInSettingsProvider() throws {
+        XCTAssertNil(self.wrapper.configurationStorage?.string(forKey: "key"))
+
+        self.wrapper.setup(for: self.wrapper.qaMenu)
+
+        self.wrapper.sut = "value"
+
+        XCTAssertEqual(self.wrapper.configurationStorage?.string(forKey: "key"), "value")
+    }
+
+    func test_wrappedValue_afterSetupWasCalled_whenNoValidValueWasSet_isDefaultValue() throws {
+        self.wrapper.setup(for: self.wrapper.qaMenu)
+        self.wrapper.sut = "value"
+
+        self.wrapper.configurationStorage?.set("invalid", forKey: "key")
+
+        XCTAssertEqual(self.wrapper.sut, "default")
+    }
+
+    // MARK: - wrappedValue
+
+    func test_wasValueInitiallySet_whenValueWasNotSet_returnsFalse() throws {
+        self.wrapper.setup(for: self.wrapper.qaMenu)
+
+        XCTAssertFalse(self.wrapper.wasValueInitiallySet)
+    }
+
+    func test_wasValueInitiallySet_whenValueWasSet_returnsTrue() throws {
+        self.wrapper.setup(for: self.wrapper.qaMenu)
+        self.wrapper.sut = "value"
+
+        XCTAssertTrue(self.wrapper.wasValueInitiallySet)
+    }
+
+    // MARK: - updateValue
+
+    func test_updateValue_whenModeIsInitialValueAndValueIsAlradySet_doesNotReplaceIt() throws {
+        self.wrapper.setup(for: self.wrapper.qaMenu)
+        self.wrapper.sut = "initial"
+
+        self.wrapper.updateValue(with: "updated", mode: .initialValue)
+
+        XCTAssertEqual(self.wrapper.sut, "initial")
+    }
+
+    func test_updateValue_whenModeIsInitialValueAndValueWasNotSet_doesReplaceIt() throws {
+        self.wrapper.setup(for: self.wrapper.qaMenu)
+
+        self.wrapper.updateValue(with: "updated", mode: .initialValue)
+
+        XCTAssertEqual(self.wrapper.sut, "updated")
+    }
+
+    func test_updateValue_whenModeIsForceReplaceAndValueIsAlreadySet_doesReplaceIt() throws {
+        self.wrapper.setup(for: self.wrapper.qaMenu)
+        self.wrapper.sut = "initial"
+
+        self.wrapper.updateValue(with: "updated", mode: .forceReplace)
+
+        XCTAssertEqual(self.wrapper.sut, "updated")
+    }
+
+    func test_updateValue_whenModeIsForceReplaceAndValueWasNotSet_doesSetIt() throws {
+        self.wrapper.setup(for: self.wrapper.qaMenu)
+
+        self.wrapper.updateValue(with: "updated", mode: .forceReplace)
+
+        XCTAssertEqual(self.wrapper.sut, "updated")
+    }
+}
+
+// MARK: - String + QAMenuConfigurationItemStorable
+
+extension String: QAMenuConfigurationItemStorable {
+
+    public init?(stringValue: String) {
+        if stringValue == "invalid" {
+            return nil
+        }
+        self = stringValue
+    }
+
+    public var toString: String {
+        return self
+    }
+}

--- a/Tests/QAMenu-UnitTests/QAMenuTests.swift
+++ b/Tests/QAMenu-UnitTests/QAMenuTests.swift
@@ -54,16 +54,77 @@ class QAMenuTests: XCTestCase {
 
     // MARK: - Init
 
-    func test_init_whenGivenRootPaneAndPresenter() throws {
-        let mockPane = RootPane(items: [])
-        let sut = QAMenu(pane: mockPane, presenterType: MockQAMenuPresenter.self)
+    func test_init_whenGivenPresenter() throws {
+        let sut = QAMenu(
+            presenterType: MockQAMenuPresenter.self
+        )
 
-        XCTAssertEqual(sut.pane, mockPane)
-        XCTAssertEqual(sut.trigger, .shake)
+        XCTAssertEqual(sut.identifier, "QAMenu")
+        XCTAssertNil(sut.pane)
+        XCTAssertEqual(sut.trigger, [.shake])
         XCTAssert(sut.presenter.self is MockQAMenuPresenter)
 
         XCTAssertEqual(QAMenu.instances.count, 1)
         XCTAssert(QAMenu.instances.last?.unbox === sut)
+    }
+
+    func test_init_whenGivenPaneAndPresenter() throws {
+        let mockPane = RootPane(items: [])
+        let sut = QAMenu(
+            pane: mockPane,
+            presenterType: MockQAMenuPresenter.self
+        )
+
+        XCTAssertEqual(sut.identifier, "QAMenu")
+        XCTAssertEqual(sut.pane, mockPane)
+        XCTAssertEqual(sut.trigger, [.shake])
+        XCTAssert(sut.presenter.self is MockQAMenuPresenter)
+
+        XCTAssertEqual(QAMenu.instances.count, 1)
+        XCTAssert(QAMenu.instances.last?.unbox === sut)
+    }
+
+    func test_init_whenGivenIdentifierAndPaneAndPresenter() throws {
+        let mockPane = RootPane(items: [])
+        let sut = QAMenu(
+            identifier: "unittest",
+            pane: mockPane,
+            presenterType: MockQAMenuPresenter.self
+        )
+
+        XCTAssertEqual(sut.identifier, "unittest")
+        XCTAssertEqual(sut.pane, mockPane)
+        XCTAssertEqual(sut.trigger, [.shake])
+        XCTAssert(sut.presenter.self is MockQAMenuPresenter)
+
+        XCTAssertEqual(QAMenu.instances.count, 1)
+        XCTAssert(QAMenu.instances.last?.unbox === sut)
+    }
+
+    // MARK: - setRootPane
+
+    func test_setRootPane_whenPaneWasNil_setsGivenPane() {
+        let sut = QAMenu(
+            presenterType: MockQAMenuPresenter.self
+        )
+
+        let mockPane = RootPane(items: [])
+        sut.setRootPane(mockPane)
+
+        XCTAssertEqual(sut.pane, mockPane)
+    }
+
+    func test_setRootPane_whenPaneWasNotNil_replacesExistingPane() {
+        let initalMockPane = RootPane(items: [])
+        let sut = QAMenu(
+            pane: initalMockPane,
+            presenterType: MockQAMenuPresenter.self
+        )
+
+        let secondMockPane = RootPane(items: [])
+        sut.setRootPane(secondMockPane)
+
+        XCTAssertEqual(sut.pane, secondMockPane)
     }
 
     // MARK: - onShakeRecognized

--- a/Tests/QAMenuUIKit-UnitTests/QAMenuLifecycleManagerTests.swift
+++ b/Tests/QAMenuUIKit-UnitTests/QAMenuLifecycleManagerTests.swift
@@ -137,22 +137,21 @@ class QAMenuLifecycleManagerTests: XCTestCase {
         XCTAssertEqual(self.lastPresenter._resetRootViewControllerCount, 0)
         // Verify that reset is not called too early
         let notCalledTooEarlyExpectation = expectation(description: "reset is not called too early")
-        notCalledTooEarlyExpectation.isInverted = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.9) {
             XCTAssertEqual(self.lastPresenter._resetRootViewControllerCount, 0)
             notCalledTooEarlyExpectation.fulfill()
         }
 
         sut.onQAMenuWasClosed()
 
-        wait(for: [notCalledTooEarlyExpectation], timeout: 0.99)
+        wait(for: [notCalledTooEarlyExpectation], timeout: 1)
 
         // Verify that reset is called afterwards
         let delay = expectation(description: "execution is delayed")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             delay.fulfill()
         }
-        wait(for: [delay], timeout: 0.02)
+        wait(for: [delay], timeout: 0.2)
 
         XCTAssertEqual(self.lastPresenter._resetRootViewControllerCount, 1)
     }

--- a/Tests/QAMenuUIKit-UnitTests/QAMenuLifecycleManagerTests.swift
+++ b/Tests/QAMenuUIKit-UnitTests/QAMenuLifecycleManagerTests.swift
@@ -40,7 +40,7 @@ class QAMenuLifecycleManagerTests: XCTestCase {
     }
     var lastPresenter: QAMenuPresenterMock!
 
-    func makeSut(dismissBehavior: QAMenuDismissBehavior) -> QAMenuLifecycleManager {
+    func makeSut(dismissBehavior: QAMenu.DismissBehavior) -> QAMenuLifecycleManager {
         self.lastPresenter = QAMenuPresenterMock(qaMenu: self.menu)
         return QAMenuLifecycleManager(
             presenter: self.lastPresenter,

--- a/Tests/QAMenuUIKit-UnitTests/QAMenuUIKitPresenterTests.swift
+++ b/Tests/QAMenuUIKit-UnitTests/QAMenuUIKitPresenterTests.swift
@@ -42,7 +42,7 @@ class QAMenuUIKitPresenterTests: XCTestCase {
             pane: RootPane(title: .static(""), items: []),
             presenterType: QAMenuUIKitPresenter.self
         )
-        self.sut = QAMenuUIKitPresenter(qaMenu: self.menu)
+        self.sut = QAMenuUIKitPresenter(qaMenu: self.menu, dismissBehavior: .resetAfter(30))
         self.sut.ui.register(RootPaneUIRepresentableMock.self, for: RootPane.self)
     }
 
@@ -60,7 +60,7 @@ class QAMenuUIKitPresenterTests: XCTestCase {
 
     func test_init_registersPaneViewController_forRootPane() throws {
         // Recreate sut to only use default elements
-        self.sut = QAMenuUIKitPresenter(qaMenu: self.menu)
+        self.sut = QAMenuUIKitPresenter(qaMenu: self.menu, dismissBehavior: .neverReset)
         XCTAssert(self.sut.ui.retrieve(for: RootPane.self) is PaneViewController.Type)
     }
 

--- a/Tests/QAMenuUIKit-UnitTests/TestDoubles/QAMenuMock.swift
+++ b/Tests/QAMenuUIKit-UnitTests/TestDoubles/QAMenuMock.swift
@@ -39,6 +39,10 @@ class QAMenuMock: QAMenu {
     }
 
     init() {
-        super.init(pane: RootPane(groups: []), presenterType: QAMenuUIKitPresenter.self)
+        super.init(
+            identifier: UUID().uuidString,
+            pane: RootPane(groups: []),
+            presenterType: QAMenuUIKitPresenter.self
+        )
     }
 }

--- a/Tests/QAMenuUIKit-UnitTests/TestDoubles/QAMenuPresenterMock.swift
+++ b/Tests/QAMenuUIKit-UnitTests/TestDoubles/QAMenuPresenterMock.swift
@@ -34,12 +34,15 @@ class QAMenuPresenterMock: QAMenuPresenter {
 
     var _resetRootViewControllerCount = 0
 
-    var dismissBehavior: QAMenuDismissBehavior
+    var dismissBehavior: QAMenu.DismissBehavior
 
     // MARK: - Initialization
 
-    required init(qaMenu: QAMenu) {
-        dismissBehavior = .neverReset
+    required init(
+        qaMenu: QAMenu,
+        dismissBehavior: QAMenu.DismissBehavior = .neverReset
+    ) {
+        self.dismissBehavior = dismissBehavior
     }
 
     // MARK: - Methods

--- a/Tests/QAMenuUIKit-UnitTests/UIWindow+ShakeGestureTests.swift
+++ b/Tests/QAMenuUIKit-UnitTests/UIWindow+ShakeGestureTests.swift
@@ -37,7 +37,7 @@ class UIWindowShakeGestureTests: XCTestCase {
 
     func test_motionEnded_whenMotionIsShake_andQAMenuShakeEnabled_forwardsEvent() throws {
         let menu = QAMenuMock()
-        menu.trigger = .shake
+        menu.setTrigger([.shake], mode: .forceReplace)
         QAMenu.instances.append(WeakBox(menu))
         let sut = UIWindow()
 
@@ -50,7 +50,7 @@ class UIWindowShakeGestureTests: XCTestCase {
 
     func test_motionEnded_whenMotionIsNotShake_andQAMenuShakeEnabled_forwardsEvent() throws {
         let menu = QAMenuMock()
-        menu.trigger = .shake
+        menu.setTrigger([.shake], mode: .forceReplace)
         QAMenu.instances.append(WeakBox(menu))
         let sut = UIWindow()
 
@@ -63,7 +63,7 @@ class UIWindowShakeGestureTests: XCTestCase {
 
     func test_motionEnded_whenMotionIsShake_andQAMenuShakeDisabled_doesNotForwardsEvent() throws {
         let menu = QAMenuMock()
-        menu.trigger = []
+        menu.setTrigger([], mode: .forceReplace)
         QAMenu.instances.append(WeakBox(menu))
         let sut = UIWindow()
 
@@ -76,7 +76,7 @@ class UIWindowShakeGestureTests: XCTestCase {
 
     func test_motionEnded_whenMotionIsNotShake_andQAMenuShakeDisabled_doesNotForwardsEvent() throws {
         let menu = QAMenuMock()
-        menu.trigger = []
+        menu.setTrigger([], mode: .forceReplace)
         QAMenu.instances.append(WeakBox(menu))
         let sut = UIWindow()
 
@@ -89,9 +89,9 @@ class UIWindowShakeGestureTests: XCTestCase {
 
     func test_motionEnded_whenHavingMultipleMenus_forwardsOnlyToLastAddedInstance() throws {
         let menu1 = QAMenuMock()
-        menu1.trigger = .shake
+        menu1.setTrigger([.shake], mode: .forceReplace)
         let menu2 = QAMenuMock()
-        menu2.trigger = .shake
+        menu2.setTrigger([.shake], mode: .forceReplace)
         QAMenu.instances.append(WeakBox(menu2))
         QAMenu.instances.append(WeakBox(menu1))
         let sut = UIWindow()
@@ -107,9 +107,9 @@ class UIWindowShakeGestureTests: XCTestCase {
 
     func test_motionEnded_whenHavingMultipleMenus_butOnlyWithShakeEnavled_forwardsToEnabledMenu() throws {
         let menu1 = QAMenuMock()
-        menu1.trigger = []
+        menu1.setTrigger([], mode: .forceReplace)
         let menu2 = QAMenuMock()
-        menu2.trigger = .shake
+        menu2.setTrigger([.shake], mode: .forceReplace)
         QAMenu.instances.append(WeakBox(menu2))
         QAMenu.instances.append(WeakBox(menu1))
         let sut = UIWindow()
@@ -125,9 +125,9 @@ class UIWindowShakeGestureTests: XCTestCase {
 
     func test_motionEnded_whenHavingMultipleMenus_butMotionIsNotAShake_doesNotForwardsEvent() throws {
         let menu1 = QAMenuMock()
-        menu1.trigger = .shake
+        menu1.setTrigger([.shake], mode: .forceReplace)
         let menu2 = QAMenuMock()
-        menu2.trigger = .shake
+        menu2.setTrigger([.shake], mode: .forceReplace)
         QAMenu.instances.append(WeakBox(menu2))
         QAMenu.instances.append(WeakBox(menu1))
         let sut = UIWindow()


### PR DESCRIPTION
The two configuration items trigger and dismiss behavior are now both settable from the outside and additionally backed by user defaults. This makes it possible to provide catalog items which show those configurations and also to allow users to change them during the runtime in the menu itself.