### PR TITLE
Make Pane's reloadable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,17 @@
 #### Breaking Changes
 
 * [QAMenu] `Group.items`, `ItemGroup.items` and `PickerGroup.options` are now wrapped in the new `Delayed` type (PR #10)
+* [QAMenu] The parameter `isSearchable` is renamed to `isPaneSearchable` in `Group.asChildPaneItem` (PR #11)
 
 #### Enhancements
 
 * [QAMenu] Added new item type `EditableStringItem` which allows to edit Strings (PR #9)
 * [QAMenu] `Group.items`, `ItemGroup.items` and `PickerGroup.options` loading can now be delayed until they are presented on the screen (PR #10)
 * [QAMenu] New item `ProgressItem` can be used to show a progress (and error message) (PR #10)
+* [QAMenu] `Pane`s can now be declared as reloadable (PR #11)
 * [QAMenuUIKit] `EditableStringItem`s can be edited with a simple UIAlertViewController (PR #9)
 * [QAMenuUIKit] Added view for new `ProgressItem` (PR #10)
+* [QAMenuUIKit] Reloadable panes can be reloaded with pull-to-refresh (PR #11)
 
 #### Bug Fixes
 

--- a/Examples/Example-iOS/Sources/Showcase/AdvancedExamples/MultipleAsyncPickerGroups.swift
+++ b/Examples/Example-iOS/Sources/Showcase/AdvancedExamples/MultipleAsyncPickerGroups.swift
@@ -136,7 +136,8 @@ struct MultipleAsyncPickerGroups {
                 headerGroup,
                 productionGroup,
                 stagingGroup
-            ]
+            ],
+            isReloadable: true
         )
     }
 }

--- a/Sources/QAMenu/Public/Data Structure/Group.swift
+++ b/Sources/QAMenu/Public/Data Structure/Group.swift
@@ -51,11 +51,16 @@ extension Group {
     // MARK: Title is extracted from group
 
     public func asPane(
+        isReloadable: Bool = false,
         isSearchable: Bool = false
     ) -> Pane {
         let groupTitle = self.title ?? .static("")
         self.removeTitle()
-        return self.asPane(title: groupTitle, isSearchable: isSearchable)
+        return self.asPane(
+            title: groupTitle,
+            isReloadable: isReloadable,
+            isSearchable: isSearchable
+        )
     }
 
     public func asChildPaneItem(
@@ -63,10 +68,12 @@ extension Group {
         footerText: Dynamic<String?>? = nil,
         layoutType: Dynamic<StringItem.LayoutType> = .static(.horizontal(.singleLine)),
         fallbackString: String = "",
-        isSearchable: Bool = false
+        isPaneReloadable: Bool = false,
+        isPaneSearchable: Bool = false
     ) -> ChildPaneItem {
         return self.asPane(
-            isSearchable: isSearchable
+            isReloadable: isPaneReloadable,
+            isSearchable: isPaneSearchable
         )
         .asChildPaneItem(
             value: value,
@@ -80,10 +87,12 @@ extension Group {
 
     public func asPane(
         title: Dynamic<String?>,
+        isReloadable: Bool = false,
         isSearchable: Bool = false
     ) -> Pane {
         return [self].asPane(
             title: title,
+            isReloadable: isReloadable,
             isSearchable: isSearchable
         )
     }
@@ -94,11 +103,13 @@ extension Group {
         footerText: Dynamic<String?>? = nil,
         layoutType: Dynamic<StringItem.LayoutType> = .static(.horizontal(.singleLine)),
         fallbackString: String = "",
+        isPaneReloadable: Bool = false,
         isPaneSearchable: Bool = false
     ) -> ChildPaneItem {
         return Pane(
             title: title,
             groups: [self],
+            isReloadable: isPaneReloadable,
             isSearchable: isPaneSearchable
         )
         .asChildPaneItem(
@@ -116,11 +127,13 @@ extension Array where Element: Group {
 
     public func asPane(
         title: Dynamic<String?>,
+        isReloadable: Bool = false,
         isSearchable: Bool = false
     ) -> Pane {
         return Pane(
             title: title,
             groups: self,
+            isReloadable: isReloadable,
             isSearchable: isSearchable
         )
     }
@@ -131,10 +144,12 @@ extension Array where Element: Group {
         footerText: Dynamic<String?>? = nil,
         layoutType: Dynamic<StringItem.LayoutType> = .static(.horizontal(.singleLine)),
         fallbackString: String = "",
+        isPaneReloadable: Bool = false,
         isPaneSearchable: Bool = false
     ) -> ChildPaneItem {
         let pane = self.asPane(
             title: title,
+            isReloadable: isPaneReloadable,
             isSearchable: isPaneSearchable
         )
         return pane.asChildPaneItem(

--- a/Sources/QAMenu/Public/Data Structure/Item.swift
+++ b/Sources/QAMenu/Public/Data Structure/Item.swift
@@ -64,12 +64,14 @@ extension Item {
 
     public func asPane(
         title: Dynamic<String?>,
+        isReloadable: Bool = false,
         isSearchable: Bool = false
     ) -> Pane {
         return [self]
             .asItemGroup()
             .asPane(
                 title: title,
+                isReloadable: isReloadable,
                 isSearchable: isSearchable
             )
     }
@@ -80,11 +82,13 @@ extension Item {
         footerText: Dynamic<String?>? = nil,
         layoutType: Dynamic<StringItem.LayoutType> = .static(.horizontal(.singleLine)),
         fallbackString: String = "",
+        isPaneReloadable: Bool = false,
         isPaneSearchable: Bool = false
     ) -> ChildPaneItem {
         return [self]
             .asPane(
                 title: title,
+                isReloadable: isPaneReloadable,
                 isSearchable: isPaneSearchable
             )
             .asChildPaneItem(
@@ -113,12 +117,14 @@ extension Array where Element: Item {
 
     public func asPane(
         title: Dynamic<String?>,
+        isReloadable: Bool = false,
         isSearchable: Bool = false
     ) -> Pane {
         return self
             .asItemGroup()
             .asPane(
                 title: title,
+                isReloadable: isReloadable,
                 isSearchable: isSearchable
             )
     }
@@ -129,11 +135,13 @@ extension Array where Element: Item {
         footerText: Dynamic<String?>? = nil,
         layoutType: Dynamic<StringItem.LayoutType> = .static(.horizontal(.singleLine)),
         fallbackString: String = "",
+        isPaneReloadable: Bool = false,
         isPaneSearchable: Bool = false
     ) -> ChildPaneItem {
         return self
             .asPane(
                 title: title,
+                isReloadable: isPaneReloadable,
                 isSearchable: isPaneSearchable
             )
             .asChildPaneItem(

--- a/Sources/QAMenu/Public/Data Structure/Pane.swift
+++ b/Sources/QAMenu/Public/Data Structure/Pane.swift
@@ -38,6 +38,7 @@ open class Pane: NSObject, Invalidatable {
 
     public let title: Dynamic<String?>
     public let groups: [Group]
+    public let isReloadable: Bool
     public let isSearchable: Bool
 
     open var onInvalidation = InvalidationEvent()
@@ -47,6 +48,7 @@ open class Pane: NSObject, Invalidatable {
     public convenience init(
         title: Dynamic<String?>,
         items: [Item],
+        isReloadable: Bool = false,
         isSearchable: Bool = false
     ) {
         self.init(
@@ -61,16 +63,26 @@ open class Pane: NSObject, Invalidatable {
     public init(
         title: Dynamic<String?>,
         groups: [Group],
+        isReloadable: Bool = false,
         isSearchable: Bool = false
     ) {
         self.title = title
         self.groups = groups
+        self.isReloadable = isReloadable
         self.isSearchable = isSearchable
         super.init()
     }
 
     open func onIsPresented() {
-      self.groups.forEach { $0.loadContent() }
+        self.groups.forEach { $0.loadContent() }
+    }
+
+    open func onReload() {
+        guard self.isReloadable else {
+            return
+        }
+        self.invalidate()
+        self.groups.forEach { $0.loadContent() }
     }
 
     open func invalidate() {

--- a/Tests/QAMenu-UnitTests/Data Structures/ItemGroupTests+Conversions.swift
+++ b/Tests/QAMenu-UnitTests/Data Structures/ItemGroupTests+Conversions.swift
@@ -59,6 +59,7 @@ extension ItemGroupTests {
 
         let pane = group.asPane(
             title: .static("title"),
+            isReloadable: true,
             isSearchable: true
         )
 
@@ -66,6 +67,7 @@ extension ItemGroupTests {
             pane,
             title: "title",
             itemGroups: [group],
+            isReloadable: true,
             isSearchable: true
         )
     }
@@ -116,6 +118,7 @@ extension ItemGroupTests {
 
         let pane = groups.asPane(
             title: .static("title"),
+            isReloadable: true,
             isSearchable: true
         )
 
@@ -123,6 +126,7 @@ extension ItemGroupTests {
             pane,
             title: "title",
             itemGroups: groups,
+            isReloadable: true,
             isSearchable: true
         )
     }
@@ -159,6 +163,7 @@ extension ItemGroupTests {
             footerText: .static("footer"),
             layoutType: .static(.vertical(.autoGrow)),
             fallbackString: "fallback",
+            isPaneReloadable: true,
             isPaneSearchable: true
         )
 
@@ -169,7 +174,9 @@ extension ItemGroupTests {
             value: "value",
             footerText: "footer",
             layoutType: .vertical(.autoGrow),
-            fallbackString: "fallback"
+            fallbackString: "fallback",
+            isPaneReloadable: true,
+            isPaneSearchable: true
         )
     }
 
@@ -221,6 +228,7 @@ extension ItemGroupTests {
             footerText: .static("footer"),
             layoutType: .static(.vertical(.autoGrow)),
             fallbackString: "fallback",
+            isPaneReloadable: true,
             isPaneSearchable: true
         )
 
@@ -231,7 +239,9 @@ extension ItemGroupTests {
             value: "value",
             footerText: "footer",
             layoutType: .vertical(.autoGrow),
-            fallbackString: "fallback"
+            fallbackString: "fallback",
+            isPaneReloadable: true,
+            isPaneSearchable: true
         )
     }
 }

--- a/Tests/QAMenu-UnitTests/Data Structures/ItemTests+Conversions.swift
+++ b/Tests/QAMenu-UnitTests/Data Structures/ItemTests+Conversions.swift
@@ -113,6 +113,7 @@ extension ItemTests {
 
         let pane = item.asPane(
             title: .static("title"),
+            isReloadable: true,
             isSearchable: true
         )
 
@@ -120,6 +121,7 @@ extension ItemTests {
             pane,
             title: "title",
             items: [item],
+            isReloadable: true,
             isSearchable: true
         )
     }
@@ -148,6 +150,7 @@ extension ItemTests {
 
         let pane = items.asPane(
             title: .static("title"),
+            isReloadable: true,
             isSearchable: true
         )
 
@@ -155,6 +158,7 @@ extension ItemTests {
             pane,
             title: "title",
             items: items,
+            isReloadable: true,
             isSearchable: true
         )
     }
@@ -184,6 +188,7 @@ extension ItemTests {
             footerText: .static("footer"),
             layoutType: .static(.vertical(.autoGrow)),
             fallbackString: "fallback",
+            isPaneReloadable: true,
             isPaneSearchable: true
         )
 
@@ -195,6 +200,7 @@ extension ItemTests {
             footerText: "footer",
             layoutType: .vertical(.autoGrow),
             fallbackString: "fallback",
+            isPaneReloadable: true,
             isPaneSearchable: true
         )
     }
@@ -229,6 +235,7 @@ extension ItemTests {
             footerText: .static("footer"),
             layoutType: .static(.vertical(.autoGrow)),
             fallbackString: "fallback",
+            isPaneReloadable: true,
             isPaneSearchable: true
         )
 
@@ -240,6 +247,7 @@ extension ItemTests {
             footerText: "footer",
             layoutType: .vertical(.autoGrow),
             fallbackString: "fallback",
+            isPaneReloadable: true,
             isPaneSearchable: true
         )
     }

--- a/Tests/QAMenu-UnitTests/Data Structures/PaneTests.swift
+++ b/Tests/QAMenu-UnitTests/Data Structures/PaneTests.swift
@@ -120,4 +120,26 @@ class PaneTests: XCTestCase {
 
         XCTAssertEqual(group._loadContentCallCount, 1)
     }
+
+    func test_onReload_whenPaneIsReloadable_callsLoadContentOnGroups() throws {
+        let group = MockGroup()
+        let sut = Pane(title: .static(""), groups: [group], isReloadable: true)
+
+        XCTAssertEqual(group._loadContentCallCount, 0)
+
+        sut.onReload()
+
+        XCTAssertEqual(group._loadContentCallCount, 1)
+    }
+
+    func test_onReload_whenPaneIsNotReloadable_callsNotLoadContentOnGroups() throws {
+        let group = MockGroup()
+        let sut = Pane(title: .static(""), groups: [group], isReloadable: false)
+
+        XCTAssertEqual(group._loadContentCallCount, 0)
+
+        sut.onReload()
+
+        XCTAssertEqual(group._loadContentCallCount, 0)
+    }
 }

--- a/Tests/QAMenu-UnitTests/Data Structures/PickerGroupTests+Conversions.swift
+++ b/Tests/QAMenu-UnitTests/Data Structures/PickerGroupTests+Conversions.swift
@@ -69,6 +69,7 @@ extension PickerGroupTests {
 
         let pane = group.asPane(
             title: .static("title"),
+            isReloadable: true,
             isSearchable: true
         )
 
@@ -78,6 +79,7 @@ extension PickerGroupTests {
             pickerGroups: [group],
             footerText: "footer",
             onPickedOptionFailure: "failure",
+            isReloadable: true,
             isSearchable: true,
             testCase: self
         )
@@ -133,6 +135,7 @@ extension PickerGroupTests {
 
         let pane = groups.asPane(
             title: .static("title"),
+            isReloadable: true,
             isSearchable: true
         )
 
@@ -142,6 +145,7 @@ extension PickerGroupTests {
             pickerGroups: groups,
             footerText: "footer",
             onPickedOptionFailure: "failure",
+            isReloadable: true,
             isSearchable: true,
             testCase: self
         )
@@ -189,6 +193,7 @@ extension PickerGroupTests {
             footerText: .static("footer"),
             layoutType: .static(.vertical(.autoGrow)),
             fallbackString: "fallback",
+            isPaneReloadable: true,
             isPaneSearchable: true
         )
 
@@ -200,6 +205,8 @@ extension PickerGroupTests {
             footerText: "footer",
             layoutType: .vertical(.autoGrow),
             fallbackString: "fallback",
+            isPaneReloadable: true,
+            isPaneSearchable: true,
             onPickedOptionFailure: "failure",
             testCase: self
         )
@@ -259,6 +266,7 @@ extension PickerGroupTests {
             footerText: .static("footer"),
             layoutType: .static(.vertical(.autoGrow)),
             fallbackString: "fallback",
+            isPaneReloadable: true,
             isPaneSearchable: true
         )
 
@@ -270,6 +278,8 @@ extension PickerGroupTests {
             footerText: "footer",
             layoutType: .vertical(.autoGrow),
             fallbackString: "fallback",
+            isPaneReloadable: true,
+            isPaneSearchable: true,
             onPickedOptionFailure: "failure",
             testCase: self
         )

--- a/Tests/QAMenu-UnitTests/Mocks/Assertations/Items/ChildPaneItem+Assert.swift
+++ b/Tests/QAMenu-UnitTests/Mocks/Assertations/Items/ChildPaneItem+Assert.swift
@@ -100,6 +100,7 @@ extension ChildPaneItem {
         footerText: String? = nil,
         layoutType: StringItem.LayoutType = .horizontal(.singleLine),
         fallbackString: String = "",
+        isPaneReloadable: Bool = false,
         isPaneSearchable: Bool = false,
         file: StaticString = #file,
         line: UInt = #line
@@ -116,6 +117,7 @@ extension ChildPaneItem {
             pane,
             title: pane.title.unboxed,
             items: items,
+            isReloadable: isPaneReloadable,
             isSearchable: isPaneSearchable
         )
         self._assertInitProperties(
@@ -138,6 +140,7 @@ extension ChildPaneItem {
         footerText: String? = nil,
         layoutType: StringItem.LayoutType = .horizontal(.singleLine),
         fallbackString: String = "",
+        isPaneReloadable: Bool = false,
         isPaneSearchable: Bool = false,
         file: StaticString = #file,
         line: UInt = #line
@@ -199,6 +202,8 @@ extension ChildPaneItem {
         footerText: String? = nil,
         layoutType: StringItem.LayoutType = .horizontal(.singleLine),
         fallbackString: String = "",
+        isPaneReloadable: Bool = false,
+        isPaneSearchable: Bool = false,
         onPickedOptionFailure: String,
         testCase: XCTestCase,
         file: StaticString = #file,
@@ -214,6 +219,8 @@ extension ChildPaneItem {
         }()
 
         XCTAssertEqual(pane.groups.count, pickerGroups.count, file: file, line: line)
+        XCTAssertEqual(pane.isReloadable, isPaneReloadable, file: file, line: line)
+        XCTAssertEqual(pane.isSearchable, isPaneSearchable, file: file, line: line)
         var groupIndex = 0
         pickerGroups.forEach { pickerGroup in
             let _pickerGroup = pane.groups[groupIndex] as! PickerGroup

--- a/Tests/QAMenu-UnitTests/Mocks/Assertations/Pane+Assert.swift
+++ b/Tests/QAMenu-UnitTests/Mocks/Assertations/Pane+Assert.swift
@@ -38,6 +38,7 @@ extension Pane {
         _ _sut: Pane,
         title: String? = nil,
         items: [MockItem],
+        isReloadable: Bool = false,
         isSearchable: Bool = false,
         file: StaticString = #file,
         line: UInt = #line
@@ -52,6 +53,7 @@ extension Pane {
         self._assertInitProperties(
             _sut,
             title: title,
+            isReloadable: isReloadable,
             isSearchable: isSearchable
         )
     }
@@ -62,6 +64,7 @@ extension Pane {
         _ _sut: Pane,
         title: String? = nil,
         itemGroups: [ItemGroup],
+        isReloadable: Bool = false,
         isSearchable: Bool = false,
         file: StaticString = #file,
         line: UInt = #line
@@ -80,6 +83,7 @@ extension Pane {
         self._assertInitProperties(
             _sut,
             title: title,
+            isReloadable: isReloadable,
             isSearchable: isSearchable
         )
     }
@@ -92,6 +96,7 @@ extension Pane {
         pickerGroups: [PickerGroup],
         footerText: String? = nil,
         onPickedOptionFailure: String,
+        isReloadable: Bool = false,
         isSearchable: Bool = false,
         testCase: XCTestCase,
         file: StaticString = #file,
@@ -113,6 +118,7 @@ extension Pane {
         self._assertInitProperties(
             _sut,
             title: title,
+            isReloadable: isReloadable,
             isSearchable: isSearchable
         )
     }
@@ -122,11 +128,13 @@ extension Pane {
     private static func _assertInitProperties(
         _ _sut: Pane,
         title: String? = nil,
+        isReloadable: Bool = false,
         isSearchable: Bool = false,
         file: StaticString = #file,
         line: UInt = #line
     ) {
         XCTAssertEqual(_sut.title.unboxed, title, file: file, line: line)
+        XCTAssertEqual(_sut.isReloadable, isReloadable, file: file, line: line)
         XCTAssertEqual(_sut.isSearchable, isSearchable, file: file, line: line)
     }
 }

--- a/Tests/QAMenuUIKit-UnitTests/PaneViewControllerTests.swift
+++ b/Tests/QAMenuUIKit-UnitTests/PaneViewControllerTests.swift
@@ -63,6 +63,20 @@ class PaneViewControllerTests: XCTestCase {
         XCTAssertNotEqual(mockPane._onIsPresentedCallCount, 0)
     }
 
+    // MARK: - handleRefreshControl
+
+    func test_handleRefreshControl_callsOnOnReloadOnPane() throws {
+        let mockPane = MockPane(isReloadable: true)
+        let qaMenu = QAMenuMock()
+        let sut = PaneViewController(pane: mockPane, qaMenu: qaMenu)
+
+        XCTAssertEqual(mockPane._onReloadCallCount, 0)
+
+        sut.handleRefreshControl()
+
+        XCTAssertNotEqual(mockPane._onReloadCallCount, 1)
+    }
+
     // MARK: - presentationContext
 
     func test_presentationContext_returnsItself() throws {

--- a/Tests/QAMenuUIKit-UnitTests/TestDoubles/MockPane.swift
+++ b/Tests/QAMenuUIKit-UnitTests/TestDoubles/MockPane.swift
@@ -32,12 +32,17 @@ import QAMenu
 class MockPane: Pane {
 
     var _onIsPresentedCallCount = 0
+    var _onReloadCallCount = 0
 
-    init(title: String = "MockPane", groups: [Group] = []) {
-        super.init(title: .static(title), groups: groups)
+    init(title: String = "MockPane", groups: [Group] = [], isReloadable: Bool = false) {
+        super.init(title: .static(title), groups: groups, isReloadable: isReloadable)
     }
 
     override func onIsPresented() {
         self._onIsPresentedCallCount += 1
+    }
+
+    override func onReload() {
+        self._onReloadCallCount += 1
     }
 }


### PR DESCRIPTION
Reloading a pane invalidates all groups and loads delayed (group) items