### PR TITLE
Only allocate layout space for the `PickableStringItemView` checkmark if the checkmark is shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [QAMenuUIKit] Improved dark mode and dynamic font support (PR #14)
 * [QAMenu] Added to option to specify `TextStyle` and `LineBreak` for `StringItem`, `EditableStringItem`, `PickableStringItem` and `ChildPaneItem` (PR #16)
 * [QAMenuUIKit] Support new `TextAttribute`s: `TextStyle` and `LineBreak` (PR #16)
+* [QAMenuUIKit] `PickableStringItemView ` only allocates now layout space for the checkmark view if the checkmark is shown (PR #17)
 
 #### Bug Fixes
 

--- a/Examples/Example-iOS/Sources/Showcase/AdvancedExamples/PickerGroupAdvancedExamplesFactory.swift
+++ b/Examples/Example-iOS/Sources/Showcase/AdvancedExamples/PickerGroupAdvancedExamplesFactory.swift
@@ -35,15 +35,24 @@ class PickerGroupAdvancedExamplesFactory {
         let pane = Pane(
             title: .static("PickerGroup"),
             groups: [
-                Pane(
-                    title: .static("Selection Examples"),
-                    groups: [
-                        ShowcaseItemsFactory.DetailedItemExamples.PickerGroups.onlyOneSelection(),
-                        ShowcaseItemsFactory.DetailedItemExamples.PickerGroups.singleSelection(),
-                        ShowcaseItemsFactory.DetailedItemExamples.PickerGroups.multiSelection()
-                    ]
-                )
-                .asChildPaneItem()
+                [
+                    Pane(
+                        title: .static("Selection Examples"),
+                        groups: [
+                            ShowcaseItemsFactory.DetailedItemExamples.PickerGroups.onlyOneSelection(),
+                            ShowcaseItemsFactory.DetailedItemExamples.PickerGroups.singleSelection(),
+                            ShowcaseItemsFactory.DetailedItemExamples.PickerGroups.multiSelection()
+                        ]
+                    )
+                    .asChildPaneItem(),
+                    Pane(
+                        title: .static("Layout Examples"),
+                        groups: [
+                            ShowcaseItemsFactory.DetailedItemExamples.PickerGroups.layoutExamples()
+                        ]
+                    )
+                    .asChildPaneItem()
+                ]
                 .asItemGroup(),
                 ItemGroup(
                     title: .static("Delayed Loading"),

--- a/Examples/Example-iOS/Sources/Showcase/ShowcaseItemsFactory+DetailedItemExamples.swift
+++ b/Examples/Example-iOS/Sources/Showcase/ShowcaseItemsFactory+DetailedItemExamples.swift
@@ -170,8 +170,9 @@ extension ShowcaseItemsFactory {
                 static var onlyOneSelection: Swift.String = "1"
                 static var singleSelection: Swift.String?
                 static var multiSelection = [Swift.String]()
+                static var layoutExamplesSelection = [Swift.String]()
 
-                static let options: [Swift.String: Swift.String] = [
+                static let selectionExamplesOptions: [Swift.String: Swift.String] = [
                     "1": "Alpha",
                     "2": "Beta (invalid)",
                     "3": "Production"
@@ -179,7 +180,7 @@ extension ShowcaseItemsFactory {
             }
 
             static var onlyOneSelectionItems: [PickableStringItem] {
-                return self.Storage.options.sorted(by: { $0.key < $1.key }).map { (key, value) in
+                return self.Storage.selectionExamplesOptions.sorted(by: { $0.key < $1.key }).map { (key, value) in
                     PickableStringItem(
                         identifier: .static(key),
                         title: .static(value),
@@ -191,7 +192,7 @@ extension ShowcaseItemsFactory {
             }
 
             static var singleSelectionItems: [PickableStringItem] {
-                return self.Storage.options.sorted(by: { $0.key < $1.key }).map { (key, value) in
+                return self.Storage.selectionExamplesOptions.sorted(by: { $0.key < $1.key }).map { (key, value) in
                     PickableStringItem(
                         identifier: .static(key),
                         title: .static(value),
@@ -203,7 +204,7 @@ extension ShowcaseItemsFactory {
             }
 
             static var multiSelectionItems: [PickableStringItem] {
-                return self.Storage.options.sorted(by: { $0.key < $1.key }).map { (key, value) in
+                return self.Storage.selectionExamplesOptions.sorted(by: { $0.key < $1.key }).map { (key, value) in
                     PickableStringItem(
                         identifier: .static(key),
                         title: .static(value),
@@ -212,6 +213,48 @@ extension ShowcaseItemsFactory {
                         })
                     )
                 }
+            }
+
+            static var layoutExampleItems: [PickableStringItem] {
+                return [
+                    PickableStringItem(
+                        identifier: .static("1"),
+                        title: .static("Title (short)"),
+                        isSelected: .computed({ self.Storage.layoutExamplesSelection.contains("1") })
+                    ),
+                    PickableStringItem(
+                        identifier: .static("2"),
+                        title: .static("Title (short)"),
+                        value: .static("With a value text"),
+                        isSelected: .computed({ self.Storage.layoutExamplesSelection.contains("2") })
+                    ),
+                    PickableStringItem(
+                        identifier: .static("3"),
+                        title: .static("Title (with a medium length)"),
+                        isSelected: .computed({ self.Storage.layoutExamplesSelection.contains("3") })
+                    ),
+                    PickableStringItem(
+                        identifier: .static("4"),
+                        title: .static("Title (with a medium length)"),
+                        value: .static("With a very extensive and long value text"),
+                        footerText: .static("And footer text."),
+                        isSelected: .computed({ self.Storage.layoutExamplesSelection.contains("4") })
+                    )
+                    .withValueTextAttributes(.static(TextAttributes(textStyle: .subheadline, lineBreak: .wrapByCharacter))),
+                    PickableStringItem(
+                        identifier: .static("5"),
+                        title: .static("Title (with a very extensive and long length)"),
+                        footerText: .static("With a long and multiline footer text."),
+                        isSelected: .computed({ self.Storage.layoutExamplesSelection.contains("5") })
+                    ),
+                    PickableStringItem(
+                        identifier: .static("6"),
+                        title: .static("Title (with a very extensive and long length)"),
+                        footerText: .static("This examples uses character wrapping instead of word line wrapping for the title."),
+                        isSelected: .computed({ self.Storage.layoutExamplesSelection.contains("6") })
+                    )
+                    .withTitleTextAttributes(.static(TextAttributes(textStyle: .subheadline, lineBreak: .wrapByCharacter)))
+                ]
             }
         }
 
@@ -343,6 +386,29 @@ extension ShowcaseItemsFactory {
                         default:
                             result(.failure("Unknown option selected"))
                         }
+                    }
+                )
+                return group
+            }
+
+            static func layoutExamples(
+                title: Swift.String? = "Layout Examples",
+                shouldDismiss: Swift.Bool = false
+            ) -> PickerGroup {
+                let group = PickerGroup(
+                    title: .static(title),
+                    options: .static(PickableString.layoutExampleItems),
+                    footerText: .static("Showcases the different layout and string length combinations"),
+                    onPickedOption: { (item: PickableItem, result: ((PickerGroup.PickResult) -> Void)) in
+                        guard let item = item as? PickableStringItem else {
+                            return
+                        }
+                        if item.isSelected() {
+                            PickableString.Storage.layoutExamplesSelection.removeAll(where: { $0 == item.identifier() })
+                        } else {
+                            PickableString.Storage.layoutExamplesSelection.append(item.identifier())
+                        }
+                        result(.success(shouldDismiss: shouldDismiss))
                     }
                 )
                 return group

--- a/Examples/Example-iOS/Sources/Showcase/ShowcaseItemsFactory.swift
+++ b/Examples/Example-iOS/Sources/Showcase/ShowcaseItemsFactory.swift
@@ -92,7 +92,7 @@ class ShowcaseItemsFactory {
                         return ShowcaseItemsFactory.DetailedItemExamples.PickerGroups.onlyOneSelection(title: nil, shouldDismiss: true).asPane(title: .static("Picker"))
                     }, value: .computed({
                         let selected = ShowcaseItemsFactory.DetailedItemExamples.PickableString.Storage.onlyOneSelection
-                        return ShowcaseItemsFactory.DetailedItemExamples.PickableString.Storage.options[selected]
+                        return ShowcaseItemsFactory.DetailedItemExamples.PickableString.Storage.selectionExamplesOptions[selected]
                     })
                 ),
                 ButtonItem(

--- a/Sources/QAMenuUIKit/Resources/PickableStringItemView.xib
+++ b/Sources/QAMenuUIKit/Resources/PickableStringItemView.xib
@@ -20,44 +20,50 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="100"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="rQ8-Be-LmF">
-                    <rect key="frame" x="0.0" y="0.0" width="393" height="100"/>
+                <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="c8k-UU-YtT">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="100"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="suP-sd-BSz">
-                            <rect key="frame" x="0.0" y="0.0" width="393" height="20.5"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="rQ8-Be-LmF">
+                            <rect key="frame" x="0.0" y="29.5" width="50" height="41"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="suP-sd-BSz">
+                                    <rect key="frame" x="0.0" y="0.0" width="50" height="20.5"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="cL0-9R-XTQ"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="APx-g2-QxH">
+                                    <rect key="frame" x="0.0" y="20.5" width="50" height="20.5"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="J61-AW-Hjp"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                        </stackView>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LF6-Ua-gTE" customClass="CheckboxView" customModule="QAMenuUIKit">
+                            <rect key="frame" x="386" y="36" width="28" height="28"/>
                             <constraints>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="cL0-9R-XTQ"/>
+                                <constraint firstAttribute="height" constant="28" id="9de-wU-Gb2"/>
+                                <constraint firstAttribute="width" constant="28" id="IQn-58-bbw"/>
                             </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="APx-g2-QxH">
-                            <rect key="frame" x="0.0" y="79.5" width="393" height="20.5"/>
-                            <constraints>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="J61-AW-Hjp"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
+                        </view>
                     </subviews>
-                </stackView>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LF6-Ua-gTE" customClass="CheckboxView" customModule="QAMenuUIKit">
-                    <rect key="frame" x="393" y="36" width="28" height="28"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="28" id="9de-wU-Gb2"/>
-                        <constraint firstAttribute="width" constant="28" id="IQn-58-bbw"/>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="28" id="6Tc-P3-c9j"/>
                     </constraints>
-                </view>
+                </stackView>
             </subviews>
             <constraints>
-                <constraint firstItem="LF6-Ua-gTE" firstAttribute="centerY" secondItem="RIp-IU-gfN" secondAttribute="centerY" id="7Kt-f1-lvA"/>
-                <constraint firstItem="LF6-Ua-gTE" firstAttribute="leading" secondItem="rQ8-Be-LmF" secondAttribute="trailing" id="bTV-7G-e0v"/>
-                <constraint firstItem="rQ8-Be-LmF" firstAttribute="leading" secondItem="RIp-IU-gfN" secondAttribute="leading" id="ha7-wI-64p"/>
-                <constraint firstAttribute="trailing" secondItem="LF6-Ua-gTE" secondAttribute="trailing" constant="-7" id="kd8-Pn-32f"/>
-                <constraint firstItem="rQ8-Be-LmF" firstAttribute="top" secondItem="RIp-IU-gfN" secondAttribute="top" id="pr3-I2-8rO"/>
-                <constraint firstAttribute="bottom" secondItem="rQ8-Be-LmF" secondAttribute="bottom" id="r79-uO-Yal"/>
+                <constraint firstAttribute="bottom" secondItem="c8k-UU-YtT" secondAttribute="bottom" id="1EG-OB-k8N"/>
+                <constraint firstItem="c8k-UU-YtT" firstAttribute="leading" secondItem="RIp-IU-gfN" secondAttribute="leading" id="HOF-3a-UN0"/>
+                <constraint firstAttribute="trailing" secondItem="c8k-UU-YtT" secondAttribute="trailing" id="ahI-Mb-b6Z"/>
+                <constraint firstItem="c8k-UU-YtT" firstAttribute="top" secondItem="RIp-IU-gfN" secondAttribute="top" id="yqh-9N-47M"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>


### PR DESCRIPTION
This PR additionally adds layout examples with a few title, value footer and text attributes examples for `PickableStringItemView`s

#### Example

![no_checkmark](https://user-images.githubusercontent.com/3233717/111069707-97cf3280-84ce-11eb-90c5-7bf0f416c72f.png)
![with_checkmark](https://user-images.githubusercontent.com/3233717/111069708-9867c900-84ce-11eb-8f35-d886c0408eca.png)
